### PR TITLE
Update to EAP 7.0.9.CP.CR1

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -49,8 +49,6 @@ artifacts:
       md5: cd02482daa0398bf5500e1628d28179a
     - path: jboss-eap-7.0.8-patch.zip
       md5: daae291155a259e9f1d2255d36866551
-    - path: jbeap-13524.zip
-      md5: 9bc08980dcfbbc23226191c13b5fc6b7
 run:
       user: 185
       cmd:

--- a/image.yaml
+++ b/image.yaml
@@ -2,15 +2,15 @@ schema_version: 1
 
 name: "jboss-eap-7/eap70"
 description: "Red Hat JBoss Enterprise Application Platform 7.0 container image"
-version: "7.0.8"
+version: "7.0.9"
 from: "jboss/openjdk18-rhel7:1.1"
 labels:
     - name: "org.jboss.product"
       value: "eap"
     - name: "org.jboss.product.version"
-      value: "7.0.8.GA"
+      value: "7.0.9.GA"
     - name: "org.jboss.product.eap.version"
-      value: "7.0.8.GA"
+      value: "7.0.9.GA"
     - name: "com.redhat.deployments-dir"
       value: "/opt/eap/standalone/deployments"
     - name: "com.redhat.dev-mode"
@@ -25,9 +25,9 @@ envs:
     - name: "JBOSS_PRODUCT"
       value: "eap"
     - name: "JBOSS_EAP_VERSION"
-      value: "7.0.8.GA"
+      value: "7.0.9.GA"
     - name: "PRODUCT_VERSION"
-      value: "7.0.8.GA"
+      value: "7.0.9.GA"
     - name: "JBOSS_HOME"
       value: "/opt/eap"
     - name: "DEBUG"
@@ -47,8 +47,8 @@ artifacts:
     - path: jboss-eap-7.0.0.zip
       description: "Artifact is available on Customer Portal: https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=43891&product=appplatform&version=7.0&downloadType=distributions"
       md5: cd02482daa0398bf5500e1628d28179a
-    - path: jboss-eap-7.0.8-patch.zip
-      md5: daae291155a259e9f1d2255d36866551
+    - path: jboss-eap-7.0.9-patch.zip
+      md5: 3a6f3add70454d6aa7e45ac8dc280a18
 run:
       user: 185
       cmd:

--- a/modules/eap-7/install_eap70.sh
+++ b/modules/eap-7/install_eap70.sh
@@ -9,7 +9,7 @@ EAP_VERSION="7.0"
 unzip -q $SOURCES_DIR/$DISTRIBUTION_ZIP
 mv jboss-eap-$EAP_VERSION $JBOSS_HOME
 
-$JBOSS_HOME/bin/jboss-cli.sh -Dorg.wildfly.patching.jar.invalidation=true --command="patch apply $SOURCES_DIR/jboss-eap-7.0.8-patch.zip"
+$JBOSS_HOME/bin/jboss-cli.sh -Dorg.wildfly.patching.jar.invalidation=true --command="patch apply $SOURCES_DIR/jboss-eap-7.0.9-patch.zip"
 
 function remove_scrapped_jars {
   find $JBOSS_HOME -name \*.jar.patched -printf "%h\n" | sort | uniq | xargs rm -rv

--- a/modules/eap-7/install_eap70.sh
+++ b/modules/eap-7/install_eap70.sh
@@ -10,7 +10,6 @@ unzip -q $SOURCES_DIR/$DISTRIBUTION_ZIP
 mv jboss-eap-$EAP_VERSION $JBOSS_HOME
 
 $JBOSS_HOME/bin/jboss-cli.sh -Dorg.wildfly.patching.jar.invalidation=true --command="patch apply $SOURCES_DIR/jboss-eap-7.0.8-patch.zip"
-$JBOSS_HOME/bin/jboss-cli.sh -Dorg.wildfly.patching.jar.invalidation=true --command="patch apply $SOURCES_DIR/jbeap-13524.zip"
 
 function remove_scrapped_jars {
   find $JBOSS_HOME -name \*.jar.patched -printf "%h\n" | sort | uniq | xargs rm -rv


### PR DESCRIPTION
This PR rollbacks the application of one-off patch for 7.0.8, and then does the upgrade to next CP release - 7.0.9.