### PR TITLE
[CLOUD-2713] Make the first line a header

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-JBoss Enterprise Application Platform continuous delivery container image
+#JBoss Enterprise Application Platform continuous delivery container image
 
 NOTE: Extends link:https://github.com/jboss-container-images/jboss-openjdk-image[JBoss OpenJDK image]
 


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2713

First line in README.adoc was not a header; now it is.

Signed-off-by: Brian Stansberry <brian.stansberry@redhat.com>


