### PR TITLE
[CLOUD-2974] Forward port minor change from eap-cd-dev; move from Beta to GA; incorporate a preliminary 7.2 GA test zip

### DIFF
--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -1,10 +1,9 @@
 schema_version: 1
 
 # cp-overrides.yaml
-#
-# Artifact overrides: see dev-overrides.yaml for more information
-#
-# artifacts:
+# see dev-overrides.yaml for more information
+
+#artifacts:
 #    - name: jboss-eap-7.2.zip
 #      path: jboss-eap-7.2.0.Beta.CR2.zip
 #      sha256: 28b54f7e23966b3a8901b37e18c09f0fe09630697501b90fea5596e3345bd9cf

--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -5,8 +5,8 @@ schema_version: 1
 
 #artifacts:
 #    - name: jboss-eap-7.2.zip
-#      path: jboss-eap-7.2.0.Beta.CR2.zip
-#      sha256: 28b54f7e23966b3a8901b37e18c09f0fe09630697501b90fea5596e3345bd9cf
+#      path: jboss-eap-7.2.0.GA.CR1.zip
+#      sha256: 2eb155d4f5673215327ff0398c32f08faab9dc78cf7ceb1a0fe09613303e6bba
 
 osbs:
       repository:

--- a/dev-overrides.yaml
+++ b/dev-overrides.yaml
@@ -20,7 +20,7 @@ schema_version: 1
 # artifacts:
 #    - name: jboss-eap-cd.zip
 #      path: /some/path/to/git/wildfly/dist/target/wildfly-14.0.0.Beta1-SNAPSHOT.zip
-
+#
 # EAP:
 #artifacts:
 #    - name: jboss-eap-7.2.zip
@@ -28,6 +28,7 @@ schema_version: 1
 #      sha256: 28b54f7e23966b3a8901b37e18c09f0fe09630697501b90fea5596e3345bd9cf
 # hash values are optional, but when building for release, *must* be provided.
 
+# below is used when building images for release
 osbs:
       repository:
             name: containers/jboss-eap-7

--- a/dev-overrides.yaml
+++ b/dev-overrides.yaml
@@ -18,14 +18,14 @@ schema_version: 1
 #
 # WildFly:
 # artifacts:
-#    - name: jboss-eap-cd.zip
+#    - name: jboss-eap-7.2.zip
 #      path: /some/path/to/git/wildfly/dist/target/wildfly-14.0.0.Beta1-SNAPSHOT.zip
 #
 # EAP:
 #artifacts:
 #    - name: jboss-eap-7.2.zip
-#      path: jboss-eap-7.2.0.Beta.CR2.zip
-#      sha256: 28b54f7e23966b3a8901b37e18c09f0fe09630697501b90fea5596e3345bd9cf
+#      path: jboss-eap-7.2.0.GA.CR1.zip
+#      sha256: 2eb155d4f5673215327ff0398c32f08faab9dc78cf7ceb1a0fe09613303e6bba
 # hash values are optional, but when building for release, *must* be provided.
 
 # below is used when building images for release

--- a/image.yaml
+++ b/image.yaml
@@ -10,9 +10,9 @@ labels:
     - name: "org.jboss.product"
       value: "eap"
     - name: "org.jboss.product.version"
-      value: "7.2.0.Beta"
+      value: "7.2.0.GA"
     - name: "org.jboss.product.eap.version"
-      value: "7.2.0.Beta"
+      value: "7.2.0.GA"
     - name: "com.redhat.deployments-dir"
       value: "/opt/eap/standalone/deployments"
     - name: "com.redhat.dev-mode"
@@ -27,9 +27,9 @@ envs:
     - name: "JBOSS_PRODUCT"
       value: "eap"
     - name: "JBOSS_EAP_VERSION"
-      value: "7.2.0.Beta"
+      value: "7.2.0.GA"
     - name: "PRODUCT_VERSION"
-      value: "7.2.0.Beta"
+      value: "7.2.0.GA"
     - name: "JBOSS_HOME"
       value: "/opt/eap"
     - name: "DEBUG"
@@ -52,8 +52,8 @@ modules:
 # and built with concreate / cekit --overrides=dev-overrides.yaml etc
 artifacts:
     - name: jboss-eap-7.2.zip
-      path: jboss-eap-7.2.0.Beta.CR2.zip
-      sha256: 28b54f7e23966b3a8901b37e18c09f0fe09630697501b90fea5596e3345bd9cf
+      path: jboss-eap-7.2.0.GA.CR1.zip
+      sha256: 2eb155d4f5673215327ff0398c32f08faab9dc78cf7ceb1a0fe09613303e6bba
 
 run:
       user: 185

--- a/image.yaml
+++ b/image.yaml
@@ -47,12 +47,14 @@ modules:
           - path: modules
       install:
           - name: jboss.eap.72.base.installer
+
 # note: these should be overridden in the corresponding -override.yaml files.
 # and built with concreate / cekit --overrides=dev-overrides.yaml etc
 artifacts:
     - name: jboss-eap-7.2.zip
       path: jboss-eap-7.2.0.Beta.CR2.zip
       sha256: 28b54f7e23966b3a8901b37e18c09f0fe09630697501b90fea5596e3345bd9cf
+
 run:
       user: 185
       cmd:

--- a/rel-overrides.yaml
+++ b/rel-overrides.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 
 # rel-overrides.yaml
+# see dev-overrides.yaml for more information
 #
-# Artifact overrides: see dev-overrides.yaml for more information
-#
+# EAP:
 # artifacts:
 #    - name: jboss-eap-7.2.zip
 #      path: jboss-eap-7.2.0.Beta.CR2.zip

--- a/rel-overrides.yaml
+++ b/rel-overrides.yaml
@@ -6,8 +6,8 @@ schema_version: 1
 # EAP:
 # artifacts:
 #    - name: jboss-eap-7.2.zip
-#      path: jboss-eap-7.2.0.Beta.CR2.zip
-#      sha256: 28b54f7e23966b3a8901b37e18c09f0fe09630697501b90fea5596e3345bd9cf
+#      path: jboss-eap-7.2.0.GA.CR1.zip
+#      sha256: 2eb155d4f5673215327ff0398c32f08faab9dc78cf7ceb1a0fe09613303e6bba
 
 osbs:
       repository:


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2974

Note that this does not resolve the JIRA. It's progress toward the goal.  It doesn't resolve it because:

1) This just incorporates a test zip, not an official CR candidate zip.
2) We're evaluating dropping this image altogether and moving toward using a module.

Signed-off-by: Brian Stansberry <brian.stansberry@redhat.com>
