### PR TITLE
[CLOUD-2995] move to rehl7 base image; move product installation to modules

### DIFF
--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -1,10 +1,9 @@
 schema_version: 1
 
 # cp-overrides.yaml
-#
-# Artifact overrides: see dev-overrides.yaml for more information
-#
-# artifacts:
+# see dev-overrides.yaml for more information
+
+#artifacts:
 #    - name: jboss-eap-7.2.zip
 #      path: jboss-eap-7.2.0.Beta.CR2.zip
 #      sha256: 28b54f7e23966b3a8901b37e18c09f0fe09630697501b90fea5596e3345bd9cf

--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -5,8 +5,8 @@ schema_version: 1
 
 #artifacts:
 #    - name: jboss-eap-7.2.zip
-#      path: jboss-eap-7.2.0.Beta.CR2.zip
-#      sha256: 28b54f7e23966b3a8901b37e18c09f0fe09630697501b90fea5596e3345bd9cf
+#      path: jboss-eap-7.2.0.GA.CR1.zip
+#      sha256: 2eb155d4f5673215327ff0398c32f08faab9dc78cf7ceb1a0fe09613303e6bba
 
 osbs:
       repository:

--- a/dev-overrides.yaml
+++ b/dev-overrides.yaml
@@ -20,7 +20,7 @@ schema_version: 1
 # artifacts:
 #    - name: jboss-eap-cd.zip
 #      path: /some/path/to/git/wildfly/dist/target/wildfly-14.0.0.Beta1-SNAPSHOT.zip
-
+#
 # EAP:
 #artifacts:
 #    - name: jboss-eap-7.2.zip
@@ -28,6 +28,7 @@ schema_version: 1
 #      sha256: 28b54f7e23966b3a8901b37e18c09f0fe09630697501b90fea5596e3345bd9cf
 # hash values are optional, but when building for release, *must* be provided.
 
+# below is used when building images for release
 osbs:
       repository:
             name: containers/jboss-eap-7

--- a/dev-overrides.yaml
+++ b/dev-overrides.yaml
@@ -18,14 +18,14 @@ schema_version: 1
 #
 # WildFly:
 # artifacts:
-#    - name: jboss-eap-cd.zip
+#    - name: jboss-eap-7.2.zip
 #      path: /some/path/to/git/wildfly/dist/target/wildfly-14.0.0.Beta1-SNAPSHOT.zip
 #
 # EAP:
 #artifacts:
 #    - name: jboss-eap-7.2.zip
-#      path: jboss-eap-7.2.0.Beta.CR2.zip
-#      sha256: 28b54f7e23966b3a8901b37e18c09f0fe09630697501b90fea5596e3345bd9cf
+#      path: jboss-eap-7.2.0.GA.CR1.zip
+#      sha256: 2eb155d4f5673215327ff0398c32f08faab9dc78cf7ceb1a0fe09613303e6bba
 # hash values are optional, but when building for release, *must* be provided.
 
 # below is used when building images for release

--- a/image.yaml
+++ b/image.yaml
@@ -10,9 +10,9 @@ labels:
     - name: "org.jboss.product"
       value: "eap"
     - name: "org.jboss.product.version"
-      value: "7.2.0.Beta"
+      value: "7.2.0.GA"
     - name: "org.jboss.product.eap.version"
-      value: "7.2.0.Beta"
+      value: "7.2.0.GA"
     - name: "com.redhat.deployments-dir"
       value: "/opt/eap/standalone/deployments"
     - name: "com.redhat.dev-mode"
@@ -27,9 +27,9 @@ envs:
     - name: "JBOSS_PRODUCT"
       value: "eap"
     - name: "JBOSS_EAP_VERSION"
-      value: "7.2.0.Beta"
+      value: "7.2.0.GA"
     - name: "PRODUCT_VERSION"
-      value: "7.2.0.Beta"
+      value: "7.2.0.GA"
     - name: "JBOSS_HOME"
       value: "/opt/eap"
     - name: "DEBUG"
@@ -52,8 +52,8 @@ modules:
 # and built with concreate / cekit --overrides=dev-overrides.yaml etc
 artifacts:
     - name: jboss-eap-7.2.zip
-      path: jboss-eap-7.2.0.Beta.CR2.zip
-      sha256: 28b54f7e23966b3a8901b37e18c09f0fe09630697501b90fea5596e3345bd9cf
+      path: jboss-eap-7.2.0.GA.CR1.zip
+      sha256: 2eb155d4f5673215327ff0398c32f08faab9dc78cf7ceb1a0fe09613303e6bba
 
 run:
       user: 185

--- a/image.yaml
+++ b/image.yaml
@@ -3,64 +3,28 @@ schema_version: 1
 name: "jboss-eap-7/eap72"
 description: "Red Hat JBoss Enterprise Application Platform 7.2 container image"
 version: "7.2.0"
-from: "jboss/openjdk18-rhel7:1.1"
+from: "rhel7:7-released"
 labels:
     - name: "com.redhat.component"
       value: "jboss-eap-7-eap72-container"
-    - name: "org.jboss.product"
-      value: "eap"
-    - name: "org.jboss.product.version"
-      value: "7.2.0.GA"
-    - name: "org.jboss.product.eap.version"
-      value: "7.2.0.GA"
-    - name: "com.redhat.deployments-dir"
-      value: "/opt/eap/standalone/deployments"
-    - name: "com.redhat.dev-mode"
-      value: "DEBUG:true"
-      description: "Environment variable used to enable development mode (debugging). A value of true will enable development mode."
-    - name: "com.redhat.dev-mode.port"
-      value: "DEBUG_PORT:8787"
-      description: "Environment variable used to specify the debug port. If not set, the default EAP debug port will be used (8787). Only applicable when development mode is enabled."
-envs:
-    - name: "LAUNCH_JBOSS_IN_BACKGROUND"
-      value: "true"
-    - name: "JBOSS_PRODUCT"
-      value: "eap"
-    - name: "JBOSS_EAP_VERSION"
-      value: "7.2.0.GA"
-    - name: "PRODUCT_VERSION"
-      value: "7.2.0.GA"
-    - name: "JBOSS_HOME"
-      value: "/opt/eap"
-    - name: "DEBUG"
-      example: "true"
-      description: "Specify true to enable development mode (debugging)."
-    - name: "DEBUG_PORT"
-      example: "8787"
-      description: "Specify the port to use for debugging. If not set, the default EAP debug port will be used (8787).  Only applicable when development mode is enabled."
-ports:
-    - value: 8080
-    - value: 8787
-      expose: false
+
+packages:
+      repositories:
+          - name: base
+            id: rhel-7-server-rpms
+
 modules:
       repositories:
+          - name: cct_module
+            git:
+                  url: https://github.com/jboss-openshift/cct_module.git
+                  ref: master
           - path: modules
       install:
-          - name: jboss.eap.72.base.installer
+          - name: jboss.container.openjdk.jdk
+            version: "8"
+          - name: eap-7.2-latest
 
-# note: these should be overridden in the corresponding -override.yaml files.
-# and built with concreate / cekit --overrides=dev-overrides.yaml etc
-artifacts:
-    - name: jboss-eap-7.2.zip
-      path: jboss-eap-7.2.0.GA.CR1.zip
-      sha256: 2eb155d4f5673215327ff0398c32f08faab9dc78cf7ceb1a0fe09613303e6bba
-
-run:
-      user: 185
-      cmd:
-          - "/opt/eap/bin/standalone.sh"
-          - "-b"
-          - "0.0.0.0"
 osbs:
       repository:
             name: containers/jboss-eap-7

--- a/image.yaml
+++ b/image.yaml
@@ -47,12 +47,14 @@ modules:
           - path: modules
       install:
           - name: jboss.eap.72.base.installer
+
 # note: these should be overridden in the corresponding -override.yaml files.
 # and built with concreate / cekit --overrides=dev-overrides.yaml etc
 artifacts:
     - name: jboss-eap-7.2.zip
       path: jboss-eap-7.2.0.Beta.CR2.zip
       sha256: 28b54f7e23966b3a8901b37e18c09f0fe09630697501b90fea5596e3345bd9cf
+
 run:
       user: 185
       cmd:

--- a/modules/7.2-latest/module.yaml
+++ b/modules/7.2-latest/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: "eap-7.2-latest"
+description: "Red Hat JBoss Enterprise Application Platform 7.2 latest version install module"
+modules:
+      install:
+          - name: eap-7.2.0
+          - name: eap-install-cleanup

--- a/modules/7.2.0/install.sh
+++ b/modules/7.2.0/install.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+SOURCES_DIR=/tmp/artifacts/
+DISTRIBUTION_ZIP="jboss-eap-7.2.zip"
+
+unzip -d $SOURCES_DIR/eap-dist -q $SOURCES_DIR/$DISTRIBUTION_ZIP
+DIST_NAME=`ls $SOURCES_DIR/eap-dist`
+
+mv $SOURCES_DIR/eap-dist/$DIST_NAME $JBOSS_HOME
+
+

--- a/modules/7.2.0/module.yaml
+++ b/modules/7.2.0/module.yaml
@@ -1,0 +1,57 @@
+schema_version: 1
+
+name: "eap-7.2.0"
+description: "Red Hat JBoss Enterprise Application Platform 7.2.0 install"
+labels:
+    - name: "org.jboss.product"
+      value: "eap"
+    - name: "org.jboss.product.version"
+      value: "7.2.0.GA"
+    - name: "org.jboss.product.eap.version"
+      value: "7.2.0.GA"
+    - name: "com.redhat.deployments-dir"
+      value: "/opt/eap/standalone/deployments"
+    - name: "com.redhat.dev-mode"
+      value: "DEBUG:true"
+      description: "Environment variable used to enable development mode (debugging). A value of true will enable development mode."
+    - name: "com.redhat.dev-mode.port"
+      value: "DEBUG_PORT:8787"
+      description: "Environment variable used to specify the debug port. If not set, the default EAP debug port will be used (8787). Only applicable when development mode is enabled."
+envs:
+    - name: "LAUNCH_JBOSS_IN_BACKGROUND"
+      value: "true"
+    - name: "JBOSS_PRODUCT"
+      value: "eap"
+    - name: "JBOSS_EAP_VERSION"
+      value: "7.2.0.GA"
+    - name: "PRODUCT_VERSION"
+      value: "7.2.0.GA"
+    - name: "JBOSS_HOME"
+      value: "/opt/eap"
+    - name: "DEBUG"
+      example: "true"
+      description: "Specify true to enable development mode (debugging)."
+    - name: "DEBUG_PORT"
+      example: "8787"
+      description: "Specify the port to use for debugging. If not set, the default EAP debug port will be used (8787).  Only applicable when development mode is enabled."
+ports:
+    - value: 8080
+    - value: 8787
+      expose: false
+
+# note: these should be overridden in the corresponding -override.yaml files.
+# and built with concreate / cekit --overrides=dev-overrides.yaml etc
+artifacts:
+    - name: jboss-eap-7.2.zip
+      path: jboss-eap-7.2.0.GA.CR1.zip
+      sha256: 2eb155d4f5673215327ff0398c32f08faab9dc78cf7ceb1a0fe09613303e6bba
+
+run:
+      user: 185
+      cmd:
+          - "/opt/eap/bin/standalone.sh"
+          - "-b"
+          - "0.0.0.0"
+execute:
+    - script: install.sh
+

--- a/modules/install_cleanup/module.yaml
+++ b/modules/install_cleanup/module.yaml
@@ -1,0 +1,6 @@
+schema_version: 1
+
+name: "eap-install-cleanup"
+description: "Cleans up filesystem after EAP installation and upgrades."
+execute:
+    - script: install.sh

--- a/modules/jboss-eap-72-base-installer/module.yaml
+++ b/modules/jboss-eap-72-base-installer/module.yaml
@@ -1,6 +1,0 @@
-schema_version: 1
-
-name: jboss.eap.72.base.installer
-execute:
-    - script: install_eap.sh
-

--- a/rel-overrides.yaml
+++ b/rel-overrides.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 
 # rel-overrides.yaml
+# see dev-overrides.yaml for more information
 #
-# Artifact overrides: see dev-overrides.yaml for more information
-#
+# EAP:
 # artifacts:
 #    - name: jboss-eap-7.2.zip
 #      path: jboss-eap-7.2.0.Beta.CR2.zip

--- a/rel-overrides.yaml
+++ b/rel-overrides.yaml
@@ -6,8 +6,8 @@ schema_version: 1
 # EAP:
 # artifacts:
 #    - name: jboss-eap-7.2.zip
-#      path: jboss-eap-7.2.0.Beta.CR2.zip
-#      sha256: 28b54f7e23966b3a8901b37e18c09f0fe09630697501b90fea5596e3345bd9cf
+#      path: jboss-eap-7.2.0.GA.CR1.zip
+#      sha256: 2eb155d4f5673215327ff0398c32f08faab9dc78cf7ceb1a0fe09613303e6bba
 
 osbs:
       repository:


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2995

This is based on the commits from #104.  I want to do the work moving from Beta to GA first, and then adapt to the new module-based installer structure.