### PR TITLE
Work around no repos being added to /etc/yum.repos.d

### DIFF
--- a/container.yaml
+++ b/container.yaml
@@ -1,0 +1,2 @@
+compose:
+  pulp_repos: true

--- a/content_sets.yml
+++ b/content_sets.yml
@@ -1,0 +1,6 @@
+ppc64le:
+- rhel-7-server-for-power-le-rhscl-rpms
+- rhel-7-for-power-le-rpms
+x86_64:
+- rhel-server-rhscl-7-rpms
+- rhel-7-server-rpms

--- a/dev-overrides.yaml
+++ b/dev-overrides.yaml
@@ -30,7 +30,9 @@ schema_version: 1
 
 # below is used when building images for release
 osbs:
-      repository:
-            name: containers/jboss-eap-7
-            branch: jb-eap-7.2-dev-rhel-7
+  configuration:
+    container_file: container.yaml
+  repository:
+    name: containers/jboss-eap-7
+    branch: jb-eap-7.2-dev-rhel-7
 

--- a/image.yaml
+++ b/image.yaml
@@ -10,8 +10,9 @@ labels:
 
 packages:
       repositories:
-          - name: base
+          - name: jboss-os
             id: rhel-7-server-rpms
+          - jboss-os
 
 modules:
       repositories:

--- a/image.yaml
+++ b/image.yaml
@@ -9,10 +9,7 @@ labels:
       value: "jboss-eap-7-eap72-container"
 
 packages:
-      repositories:
-          - name: jboss-os
-            id: rhel-7-server-rpms
-          - jboss-os
+  content_sets_file: content_sets.yml
 
 modules:
       repositories:


### PR DESCRIPTION
This is a placeholder workaround for somethat that seems to have changed since yesterday so that this standalone image no long builds. The Dockerfile doesn't add any repos with just: 

 ```packages:
      repositories:
          - name: base
            id: rhel-7-server-rpms
```
But this was working as recently as yesterday.

Adding the jboss-os repo at least puts a repo file in /etc/init.d and allows the yum update to complete.

 ```packages:
      repositories:
          - name: jboss-os
            id: rhel-7-server-rpms
          - jboss-os
```

The OpenShift build is unaffected as this uses EAP 7.2 as a module, and that image.yaml has - jboss-os


Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
