### PR TITLE
[CEKit maintenance] Start to version every module of jboss-eap-7-image repo

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -24,6 +24,7 @@ modules:
           - name: jboss.container.maven.35.bash
             version: "3.5"
           - name: eap-cd-latest
+            version: "1.0"
 
 osbs:
       configuration:

--- a/modules/cd-14/module.yaml
+++ b/modules/cd-14/module.yaml
@@ -1,6 +1,7 @@
 schema_version: 1
 
 name: "eap-cd-14"
+version: "1.0"
 description: "JBoss Enterprise Application Platform CD 14 install"
 labels:
     - name: "com.redhat.component"

--- a/modules/cd-15/module.yaml
+++ b/modules/cd-15/module.yaml
@@ -1,6 +1,7 @@
 schema_version: 1
 
 name: "eap-cd-15"
+version: "1.0"
 description: "JBoss Enterprise Application Platform CD 15 install"
 labels:
     - name: "com.redhat.component"

--- a/modules/cd-16/module.yaml
+++ b/modules/cd-16/module.yaml
@@ -1,6 +1,7 @@
 schema_version: 1
 
 name: "eap-cd-16"
+version: "1.0"
 description: "JBoss Enterprise Application Platform CD 16 install"
 labels:
     - name: "com.redhat.component"

--- a/modules/cd-17/module.yaml
+++ b/modules/cd-17/module.yaml
@@ -1,6 +1,7 @@
 schema_version: 1
 
 name: "eap-cd-17"
+version: "1.0"
 description: "JBoss Enterprise Application Platform CD 17 install"
 labels:
     - name: "com.redhat.component"

--- a/modules/cd-latest/module.yaml
+++ b/modules/cd-latest/module.yaml
@@ -1,6 +1,7 @@
 schema_version: 1
 
 name: eap-cd-latest
+version: "1.0"
 description: "Red Hat JBoss Enterprise Application Platform CD latest version install module"
 modules:
       install:

--- a/modules/eap-install-cleanup/module.yaml
+++ b/modules/eap-install-cleanup/module.yaml
@@ -1,6 +1,7 @@
 schema_version: 1
 
 name: "eap-install-cleanup"
+version: "1.0"
 description: "Cleans up filesystem after EAP installation and upgrades."
 execute:
     - script: install.sh


### PR DESCRIPTION
which is now required to be able to build the image using CEKit v3.3.1.
See links below for more details:

* https://cekit.io/blog/2019/07/cekit-3.3.1-released/
* https://docs.cekit.io/en/latest/descriptor/module.html#version

Without this change it's not possible to build the images using CEKit 3.3.1 version (former versions work without issues).

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
