### PR TITLE
[CLOUD-3274] [7.2.x] After applying an EAP cumulative patch, overridden modules should be removed from the container

### DIFF
--- a/modules/7.2.4/install.sh
+++ b/modules/7.2.4/install.sh
@@ -4,4 +4,5 @@ set -e
 
 SOURCES_DIR=/tmp/artifacts/
 
+export JAVA_OPTS="${JAVA_OPTS} -Dorg.wildfly.patching.jar.invalidation=true"
 $JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jboss-eap-7.2.4-patch.zip"


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3274
Signed-off-by: Daniel Kreling dkreling@redhat.com
