### PR TITLE
[CLOUD-3410] fix name of CVE patches in install.sh

### DIFF
--- a/modules/7.2.4/install.sh
+++ b/modules/7.2.4/install.sh
@@ -6,5 +6,5 @@ SOURCES_DIR=/tmp/artifacts/
 
 export JAVA_OPTS="${JAVA_OPTS} -Dorg.wildfly.patching.jar.invalidation=true"
 $JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jboss-eap-7.2.4-patch.zip"
-$JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jbeap-17583.zip"
-$JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jbeap-17715.zip"
+$JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jbeap-17583"
+$JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jbeap-17715"


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3410

Signed-off-by: Daniel Kreling <dkreling@redhat.com>