### PR TITLE
CLOUD-3421 - 7.2.4 install module is missing cekit version field

### DIFF
--- a/modules/7.2.4/module.yaml
+++ b/modules/7.2.4/module.yaml
@@ -1,6 +1,7 @@
 schema_version: 1
 
 name: "eap-7.2.4"
+version: "1.0"
 description: "Red Hat JBoss Enterprise Application Platform 7.2.4 patch upgrade"
 labels:
     - name: "org.jboss.product.version"


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3421
Signed-off-by: Ken Wills <kwills@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
