### PR TITLE
CLOUD-3421 - 7.2.5 install module is missing cekit version field

### DIFF
--- a/modules/7.2.5/module.yaml
+++ b/modules/7.2.5/module.yaml
@@ -1,6 +1,7 @@
 schema_version: 1
 
 name: "eap-7.2.5"
+version: "1.0"
 description: "Red Hat JBoss Enterprise Application Platform 7.2.5 patch upgrade"
 labels:
     - name: "org.jboss.product.version"


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3421
Signed-off-by: Daniel Kreling <dkreling@redhat.com>