### PR TITLE
Fix for CLOUD-3453, Remove cd specific module from jboss-eap-modules

### DIFF
--- a/modules/eap-cd-env/18.0/module.yaml
+++ b/modules/eap-cd-env/18.0/module.yaml
@@ -22,6 +22,8 @@ labels:
       value: "DEBUG_PORT:8787"
       description: "Environment variable used to specify the debug port. If not set, the default EAP debug port will be used (8787). Only applicable when development mode is enabled."
 envs:
+    - name: "WILDFLY_VERSION"
+      value: "7.3.0.CD18-redhat-00002"
     - name: "LAUNCH_JBOSS_IN_BACKGROUND"
       value: "true"
     - name: "JBOSS_PRODUCT"


### PR DESCRIPTION
Signed-off-by: jdenise@redhat.com
https://issues.jboss.org/browse/CLOUD-3453

Add wildfly version env var to eap-cd-env:18.0 module