### PR TITLE
[CLOUD-3510] [7.2.x] Apply CVE-2020-1745 fix

### DIFF
--- a/modules/7.2.7/install.sh
+++ b/modules/7.2.7/install.sh
@@ -6,3 +6,4 @@ SOURCES_DIR=/tmp/artifacts/
 
 export JAVA_OPTS="${JAVA_OPTS} -Dorg.wildfly.patching.jar.invalidation=true"
 $JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jboss-eap-7.2.7-patch.zip"
+$JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jbeap-18811"

--- a/modules/7.2.7/module.yaml
+++ b/modules/7.2.7/module.yaml
@@ -17,6 +17,9 @@ artifacts:
     - name: jboss-eap-7.2.7-patch
       target: jboss-eap-7.2.7-patch.zip
       md5: 34a8787d5f5cdf54d5c1477ab1bdf47b
+    - name: jbeap-18811
+      path: jbeap-18811.zip
+      md5: c8ecfa7a0c68c3c21a3333b1e5a9c343
 modules:
       install:
           - name: eap-7.2.0

--- a/modules/7.2.7/module.yaml
+++ b/modules/7.2.7/module.yaml
@@ -18,7 +18,7 @@ artifacts:
       target: jboss-eap-7.2.7-patch.zip
       md5: 34a8787d5f5cdf54d5c1477ab1bdf47b
     - name: jbeap-18811
-      path: jbeap-18811.zip
+      target: jbeap-18811.zip
       md5: c8ecfa7a0c68c3c21a3333b1e5a9c343
 modules:
       install:


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3510

This is the an Undertow, necessary for the one-off patch of 7.2.7.GA

Signed-off-by: Daniel Kreling <dkreling@redhat.com>