### PR TITLE
[JBEAP-3510] Use correct name for the one-off .zip file

### DIFF
--- a/modules/7.2.7/install.sh
+++ b/modules/7.2.7/install.sh
@@ -6,4 +6,4 @@ SOURCES_DIR=/tmp/artifacts/
 
 export JAVA_OPTS="${JAVA_OPTS} -Dorg.wildfly.patching.jar.invalidation=true"
 $JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jboss-eap-7.2.7-patch.zip"
-$JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jbeap-18811"
+$JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jbeap-18811.zip"


### PR DESCRIPTION
PR #179 added jbeap-18811.zip with a missing ".zip" which was breaking the build. 
This commit fixes it.
Signed-off-by: Daniel Kreling <dkreling@redhat.com>