### PR TITLE
[CLOUD-3524] CVE-2019-10174 (infinispan) and CVE-2018-14371 (mojarra) fixes

### DIFF
--- a/modules/7.2.8/install.sh
+++ b/modules/7.2.8/install.sh
@@ -6,3 +6,4 @@ SOURCES_DIR=/tmp/artifacts/
 
 export JAVA_OPTS="${JAVA_OPTS} -Dorg.wildfly.patching.jar.invalidation=true"
 $JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jboss-eap-7.2.8-patch.zip"
+$JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jbeap-19359.zip"

--- a/modules/7.2.8/module.yaml
+++ b/modules/7.2.8/module.yaml
@@ -17,6 +17,10 @@ artifacts:
     - name: jboss-eap-7.2.8-patch
       target: jboss-eap-7.2.8-patch.zip
       md5: 1c7dc0a96928afb8d6ff1e456ae57de5
+    - name: jbeap-19005
+      target: jbeap-19359.zip
+      md5: ceedd909b926d3d6f34816b7bddd966d
+
 modules:
       install:
           - name: eap-7.2.0


### PR DESCRIPTION
[JBEAP-19359]  CVE-2019-10174: infinispan: invokeAccessibly method from ReflectionUtil / CVE-2018-14371: mojarra: Path traversal in ResourceManager.java:getLocalePrefix

Signed-off-by: Daniel Kreling <dkreling@redhat.com>