### PR TITLE
[EAP-CD-DEV] Fix for CLOUD-3650, Support patched image builder Maven repository

### DIFF
--- a/modules/eap-cd-galleon/20.0/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/wildfly-user-feature-pack-build.xml
+++ b/modules/eap-cd-galleon/20.0/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/wildfly-user-feature-pack-build.xml
@@ -1,0 +1,46 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<build xmlns="urn:wildfly:feature-pack-build:3.2" producer="org.jboss.eap.galleon.s2i:eap-s2i-galleon-pack">
+
+    <transitive>
+        <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack">
+            <name>org.wildfly.core:wildfly-core-galleon-pack</name>
+        </dependency>
+         <dependency group-id="org.jboss.eap" artifact-id="wildfly-servlet-galleon-pack">
+            <name>org.wildfly:wildfly-servlet-galleon-pack</name>
+        </dependency>
+         <dependency group-id="org.jboss.eap" artifact-id="wildfly-ee-galleon-pack">
+            <name>org.wildfly:wildfly-ee-galleon-pack</name>
+            <default-configs inherit="true"/>
+            <packages inherit="true"/>
+        </dependency>
+    </transitive>
+    <dependencies>
+        <dependency group-id="org.jboss.eap.cd" artifact-id="wildfly-galleon-pack">
+            <name>org.wildfly:wildfly-galleon-pack</name>
+            <packages inherit="true"/>
+            <default-configs inherit="false"/>
+            <!-- ##PATCHES## -->
+        </dependency>
+    </dependencies>
+</build>

--- a/modules/eap-cd-galleon/20.0/configure.sh
+++ b/modules/eap-cd-galleon/20.0/configure.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd

--- a/modules/eap-cd-galleon/20.0/module.yaml
+++ b/modules/eap-cd-galleon/20.0/module.yaml
@@ -1,0 +1,12 @@
+schema_version: 1
+name: eap-cd-galleon
+version: '20.0'
+description: Install Galleon feature-pack-build file with dependency on wildfly-galleon-pack, default config being inherited from wildfly-ee-galleon-pack
+
+execute:
+- script: configure.sh
+
+modules:
+      install:
+          - name: eap-cd-env
+            version: '20.0'


### PR DESCRIPTION
Fix for: https://issues.redhat.com/browse/CLOUD-3651
This fix depends on : wildfly/wildfly-cekit-modules#188
This fix depends on:  https://github.com/jboss-container-images/jboss-eap-modules/pull/202

* Introduce a new module for EAP CD 20
* Update wildfly-user-feature-pack-build.xml file to contain patches.

NB: Applies the EAP CD19 refactoring to EAP CD20. If we get ridoff dependency on https://github.com/jboss-container-images/jboss-eap-7-image for EAP CD 20, this one would have to be reviewed.