### PR TITLE
Revert "[CLOUD-3863] Update files for 7.3.4.GA and 1.0.3.GA - One-Off"

### DIFF
--- a/modules/eap-73-env/7.3.4/module.yaml
+++ b/modules/eap-73-env/7.3.4/module.yaml
@@ -21,7 +21,7 @@ labels:
       description: "Environment variable used to specify the debug port. If not set, the default EAP debug port will be used (8787). Only applicable when development mode is enabled."
 envs:
     - name: "WILDFLY_VERSION"
-      value: "7.3.4.GA-redhat-00004"
+      value: "7.3.4.GA-redhat-00003"
     - name: "LAUNCH_JBOSS_IN_BACKGROUND"
       value: "true"
     - name: "JBOSS_PRODUCT"

--- a/modules/eap-xp-10-env/1.0.3/module.yaml
+++ b/modules/eap-xp-10-env/1.0.3/module.yaml
@@ -21,7 +21,7 @@ labels:
       description: "Environment variable used to specify the debug port. If not set, the default EAP debug port will be used (8787). Only applicable when development mode is enabled."
 envs:
     - name: "WILDFLY_VERSION"
-      value: "7.3.4.GA-redhat-00004"
+      value: "7.3.4.GA-redhat-00003"
     - name: "LAUNCH_JBOSS_IN_BACKGROUND"
       value: "true"
     - name: "JBOSS_PRODUCT"


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3863

This reverts commit 63cedf604b3562f610ba23c19a481252b95828b8.

The server should not be bumped to the new 00004 version. The upgrade
of the one-off artifacts are resolved by the new image-builder maven repo
created updated in jboss-eap-7-openshift-image repository

Signed-off-by: Daniel Kreling <dkreling@redhat.com>