### PR TITLE
EAP 7.4.0 modules

### DIFF
--- a/modules/eap-74-galleon-latest/module.yaml
+++ b/modules/eap-74-galleon-latest/module.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+
+name: eap-74-galleon-latest
+version: "1.0"
+description: "Red Hat JBoss Enterprise Application Platform EAP 7.4.0 latest version galleon module"
+modules:
+      install:
+          - name: eap-74-galleon
+            version: '7.4.0'

--- a/modules/eap-74-galleon/7.4.0/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/wildfly-user-feature-pack-build.xml
+++ b/modules/eap-74-galleon/7.4.0/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/wildfly-user-feature-pack-build.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<build xmlns="urn:wildfly:feature-pack-build:3.1" producer="org.jboss.eap.galleon.s2i:eap-s2i-galleon-pack">
+    <dependencies>
+        <dependency group-id="org.jboss.eap" artifact-id="wildfly-ee-galleon-pack">
+            <name>org.wildfly:wildfly-ee-galleon-pack</name>
+            <default-configs inherit="true"/>
+            <packages inherit="true"/>
+            <!-- ##PATCHES## -->
+        </dependency>
+    </dependencies>
+</build>

--- a/modules/eap-74-galleon/7.4.0/configure.sh
+++ b/modules/eap-74-galleon/7.4.0/configure.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd

--- a/modules/eap-74-galleon/7.4.0/module.yaml
+++ b/modules/eap-74-galleon/7.4.0/module.yaml
@@ -1,0 +1,12 @@
+schema_version: 1
+name: eap-74-galleon
+version: '7.4.0'
+description: Install Galleon feature-pack-build file with dependency on wildfly-galleon-pack, default config being inherited from wildfly-ee-galleon-pack
+
+execute:
+- script: configure.sh
+
+modules:
+      install:
+          - name: eap-74-env
+            version: '7.4.0'

--- a/modules/env-74-env/7.4.0/module.yaml
+++ b/modules/env-74-env/7.4.0/module.yaml
@@ -21,7 +21,7 @@ labels:
       description: "Environment variable used to specify the debug port. If not set, the default EAP debug port will be used (8787). Only applicable when development mode is enabled."
 envs:
     - name: "WILDFLY_VERSION"
-      value: "7.4.0.GA-redhat-20210318v2"
+      value: "7.4.0.GA-redhat-20210323"
     - name: "LAUNCH_JBOSS_IN_BACKGROUND"
       value: "true"
     - name: "JBOSS_PRODUCT"

--- a/modules/env-74-env/7.4.0/module.yaml
+++ b/modules/env-74-env/7.4.0/module.yaml
@@ -21,7 +21,7 @@ labels:
       description: "Environment variable used to specify the debug port. If not set, the default EAP debug port will be used (8787). Only applicable when development mode is enabled."
 envs:
     - name: "WILDFLY_VERSION"
-      value: "7.4.0.GA-redhat-20210323"
+      value: "7.4.0.GA-redhat-20210331"
     - name: "LAUNCH_JBOSS_IN_BACKGROUND"
       value: "true"
     - name: "JBOSS_PRODUCT"

--- a/modules/env-74-env/7.4.0/module.yaml
+++ b/modules/env-74-env/7.4.0/module.yaml
@@ -1,0 +1,46 @@
+schema_version: 1
+
+name: "eap-74-env"
+description: "JBoss Enterprise Application Platform 7.4.0 env and labels"
+version: "7.4.0"
+
+labels:
+    - name: "org.jboss.product"
+      value: "eap"
+    - name: "org.jboss.product.version"
+      value: "7.4.0"
+    - name: "org.jboss.product.eap.version"
+      value: "7.4.0"
+    - name: "com.redhat.deployments-dir"
+      value: "/opt/eap/standalone/deployments"
+    - name: "com.redhat.dev-mode"
+      value: "DEBUG:true"
+      description: "Environment variable used to enable development mode (debugging). A value of true will enable development mode."
+    - name: "com.redhat.dev-mode.port"
+      value: "DEBUG_PORT:8787"
+      description: "Environment variable used to specify the debug port. If not set, the default EAP debug port will be used (8787). Only applicable when development mode is enabled."
+envs:
+    - name: "WILDFLY_VERSION"
+      value: "7.4.0.GA-redhat-20210318v2"
+    - name: "LAUNCH_JBOSS_IN_BACKGROUND"
+      value: "true"
+    - name: "JBOSS_PRODUCT"
+      value: "eap"
+    - name: "JBOSS_EAP_VERSION"
+      value: "7.4.0"
+    - name: "PRODUCT_VERSION"
+      value: "7.4.0"
+    - name: "EAP_FULL_GROUPID"
+      value: "org.jboss.eap"
+    - name: "JBOSS_HOME"
+      value: "/opt/eap"
+    - name: "DEBUG"
+      example: "true"
+      description: "Specify true to enable development mode (debugging)."
+    - name: "DEBUG_PORT"
+      example: "8787"
+      description: "Specify the port to use for debugging. If not set, the default EAP debug port will be used (8787).  Only applicable when development mode is enabled."
+ports:
+    - value: 8080
+    - value: 8787
+      expose: false


### PR DESCRIPTION
This PR depends on a test build of EAP 7.4.0 so the version NEEDS TO BE UPDATED.
Other than that, this PR captures the changes that need to be done to galleon. It can be used as a stating point for EAP 7.4.0 