### PR TITLE
[CLOUD-4011] Add missing files required to build standalone images

### DIFF
--- a/modules/eap-741/install.sh
+++ b/modules/eap-741/install.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+SOURCES_DIR=/tmp/artifacts/
+DISTRIBUTION_ZIP="jboss-eap-7.4.zip"
+
+unzip -d $SOURCES_DIR/eap-dist -q $SOURCES_DIR/$DISTRIBUTION_ZIP
+DIST_NAME=`ls $SOURCES_DIR/eap-dist`
+
+mv $SOURCES_DIR/eap-dist/$DIST_NAME $JBOSS_HOME
+
+export JAVA_OPTS="${JAVA_OPTS} -Dorg.wildfly.patching.jar.invalidation=true"
+$JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jboss-eap-7.4.1-patch.zip"

--- a/modules/eap-741/module.yaml
+++ b/modules/eap-741/module.yaml
@@ -1,0 +1,23 @@
+schema_version: 1
+
+name: eap-741
+version: "7.4.1"
+
+artifacts:
+  - name: jboss-eap-7.4.zip
+    target: jboss-eap-7.4.zip
+    md5: feddc39d58a29b1ed9791121a77e8b49
+
+  - name: jboss-eap-7.4.1-patch
+    target: jboss-eap-7.4.1-patch.zip
+    md5: e473d11220221b422bdce747c3302f72
+
+run:
+  user: 185
+  cmd:
+    - "/opt/eap/bin/standalone.sh"
+    - "-b"
+    - "0.0.0.0"
+
+execute:
+  - script: install.sh


### PR DESCRIPTION
This should be part of a new CP regular process and should have been
commited along with commit #181733da00.

https://issues.redhat.com/browse/CLOUD-4038
Signed-off-by: Daniel Kreling <dkreling@redhat.com>