### PR TITLE
[CLOUD-4048] Update to 0-day patch server

### DIFF
--- a/modules/eap-74-env/7.4.2/module.yaml
+++ b/modules/eap-74-env/7.4.2/module.yaml
@@ -21,7 +21,7 @@ labels:
       description: "Environment variable used to specify the debug port. If not set, the default EAP debug port will be used (8787). Only applicable when development mode is enabled."
 envs:
     - name: "WILDFLY_VERSION"
-      value: "7.4.2.GA-redhat-00002"
+      value: "7.4.2.GA-redhat-00003"
     - name: "LAUNCH_JBOSS_IN_BACKGROUND"
       value: "true"
     - name: "JBOSS_PRODUCT"


### PR DESCRIPTION
JBEAP-22674 files an issue with JMS integration with the wildfly-wildfly server version 00002,
and a new version 00003 had to be rebuilt with the fix.

Issue: https://issues.redhat.com/browse/CLOUD-4048
Signed-off-by: Daniel Kreling <dkreling@redhat.com>