### PR TITLE
Revert "[CLOUD-4048] Update to 0-day patch server"

### DIFF
--- a/modules/eap-74-env/7.4.2/module.yaml
+++ b/modules/eap-74-env/7.4.2/module.yaml
@@ -21,7 +21,7 @@ labels:
       description: "Environment variable used to specify the debug port. If not set, the default EAP debug port will be used (8787). Only applicable when development mode is enabled."
 envs:
     - name: "WILDFLY_VERSION"
-      value: "7.4.2.GA-redhat-00003"
+      value: "7.4.2.GA-redhat-00002"
     - name: "LAUNCH_JBOSS_IN_BACKGROUND"
       value: "true"
     - name: "JBOSS_PRODUCT"


### PR DESCRIPTION
This reverts commit 61f7ce7b787bff272058ebc08070615a232fae01.

The fix is in a piece of server 00003, and it will be included via
image-builder-maven-repo, so the server should stay at version 00002.

Issue: https://issues.redhat.com/browse/CLOUD-4048
Signed-off-by: Daniel Kreling <dkreling@redhat.com>