### PR TITLE
[KIECLOUD-625] - Upgrade EAP to 7.4 latest cp patch on RHPAM images

### DIFF
--- a/modules/eap-744/module.yaml
+++ b/modules/eap-744/module.yaml
@@ -6,7 +6,7 @@ version: "7.4.4"
 artifacts:
   - name: jboss-eap-7.4.zip
     target: jboss-eap-7.4.zip
-    md5: 58263e1daa0f08e457cd3cddb93ec49a
+    md5: feddc39d58a29b1ed9791121a77e8b49
 
   - name: jboss-eap-7.4.4-patch
     target: jboss-eap-7.4.4-patch.zip


### PR DESCRIPTION
 - 58263e1daa0f08e457cd3cddb93ec49a points to
   wildfly-ee-dist-7.4.4.GA-redhat-00010.zip which is the eap 7.4.4.GA
   already, it must point to the base jboss-eap-7.4.0.zip file.

Signed-off-by: spolti <fspolti@redhat.com>