### PR TITLE
Add one-off jbeap-25855

### DIFF
--- a/modules/eap-7413/install.sh
+++ b/modules/eap-7413/install.sh
@@ -12,3 +12,5 @@ mv $SOURCES_DIR/eap-dist/$DIST_NAME $JBOSS_HOME
 
 export JAVA_OPTS="${JAVA_OPTS} -Dorg.wildfly.patching.jar.invalidation=true"
 $JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jboss-eap-7.4.13-patch.zip"
+
+$JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jbeap-25855.zip"

--- a/modules/eap-7413/module.yaml
+++ b/modules/eap-7413/module.yaml
@@ -12,6 +12,10 @@ artifacts:
     target: jboss-eap-7.4.13-patch.zip
     md5: 48d2009329fe507a9db006677af27643
 
+  - name: jbeap-25855
+    target: jbeap-25855.zip
+    md5: 38aa86ce961d2d23830c435467da8e03
+
 run:
   user: 185
   cmd:


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/EAPPROD-826
Signed-off-by: Ruben Dario Novelli [rnovelli@redhat.com](mailto:rnovelli@redhat.com)

To use this updated module, the one off patch should be in the ceckit cache or provided using and artifact override