### PR TITLE
[JBEAP-30288] commons-beanutils CVE-2025-48734

### DIFF
--- a/modules/eap-7422/install.sh
+++ b/modules/eap-7422/install.sh
@@ -12,3 +12,6 @@ mv $SOURCES_DIR/eap-dist/$DIST_NAME $JBOSS_HOME
 
 export JAVA_OPTS="${JAVA_OPTS} -Dorg.wildfly.patching.jar.invalidation=true"
 $JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jboss-eap-7.4.22-patch.zip"
+
+
+$JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jbeap-30288.zip"

--- a/modules/eap-7422/module.yaml
+++ b/modules/eap-7422/module.yaml
@@ -12,6 +12,10 @@ artifacts:
     target: jboss-eap-7.4.22-patch.zip
     md5: ddc18797418b16779722c69dd416e1a9
 
+  - name: jbeap-30288
+    target: jbeap-30288.zip
+    md5: adb7fcda481b3b7d7d16314ac5f7d079
+
 run:
   user: 185
   cmd:


### PR DESCRIPTION
Issue: [JBEAP-30288](https://issues.redhat.com/browse/JBEAP-30288)

To use this updated module, the one off patch should be in the ceckit cache or provided using and artifact override